### PR TITLE
Remove old version of exllamav2 to use the same version on text-generation-webui

### DIFF
--- a/cuda12.1.1-ubuntu22.04-textgen/Dockerfile
+++ b/cuda12.1.1-ubuntu22.04-textgen/Dockerfile
@@ -10,10 +10,12 @@ WORKDIR /root
 
 # Install text-generation-webui, including all extensions
 # Also includes exllama
+# We remove any installed exllamav2 and use the same version used on text-generation-webui
 # We remove the ExLlama automatically installed by text-generation-webui
 # so we're always up-to-date with any ExLlama changes, which will auto compile its own extension
 RUN git clone https://github.com/oobabooga/text-generation-webui && \
     cd text-generation-webui && \
+    pip3 uninstall exllamav2 && \
     pip3 install -r requirements.txt && \
     bash -c 'for req in extensions/*/requirements.txt ; do pip3 install -r "$req" ; done' && \
     #pip3 uninstall -y exllama && \


### PR DESCRIPTION
This PR is to resolve https://github.com/TheBlokeAI/dockerLLM/issues/17 by removing the old version of exllamav2 and use the same version on text-generation-webui.

As of now when this PR created, the currently running version of exllamav2 on the template is 0.11 which breaks as text-generation-webui use version 0.15 which introduce Q4 cache mode. Hence we ran into https://github.com/TheBlokeAI/dockerLLM/issues/17 as the text-generation-webui class [ExLlamaV2Cache_Q4](https://github.com/oobabooga/text-generation-webui/blob/aa0da07af012e251b4b70a1391b0acd360f796bd/modules/exllamav2.py#L9) requires the Q4 cache mode from the new version of exllamav2 to work. 